### PR TITLE
Add missing Glock variants (Gen5, MOS, long-slide, slimline, G44)

### DIFF
--- a/db/glock/G17/G17-Gen5-MOS.json
+++ b/db/glock/G17/G17-Gen5-MOS.json
@@ -1,0 +1,7 @@
+{
+    "barrel length": "4.49 inches",
+    "caliber": "9x19mm",
+    "style": "handgun",
+    "fire mode": "semi-auto",
+    "decoder": "G17G5MOS-*****"
+}

--- a/db/glock/G17/G17-Gen5.json
+++ b/db/glock/G17/G17-Gen5.json
@@ -1,0 +1,7 @@
+{
+    "barrel length": "4.49 inches",
+    "caliber": "9x19mm",
+    "style": "handgun",
+    "fire mode": "semi-auto",
+    "decoder": "G17G5-*****"
+}

--- a/db/glock/G17L/G17L-Gen5-MOS.json
+++ b/db/glock/G17L/G17L-Gen5-MOS.json
@@ -1,0 +1,7 @@
+{
+    "barrel length": "6.02 inches",
+    "caliber": "9x19mm",
+    "style": "handgun",
+    "fire mode": "semi-auto",
+    "decoder": "G17LG5MOS-*****"
+}

--- a/db/glock/G19/G19-Gen5-MOS.json
+++ b/db/glock/G19/G19-Gen5-MOS.json
@@ -1,0 +1,7 @@
+{
+    "barrel length": "4.02 inches",
+    "caliber": "9x19mm",
+    "style": "handgun",
+    "fire mode": "semi-auto",
+    "decoder": "G19G5MOS-*****"
+}

--- a/db/glock/G19/G19-Gen5.json
+++ b/db/glock/G19/G19-Gen5.json
@@ -1,0 +1,7 @@
+{
+    "barrel length": "4.02 inches",
+    "caliber": "9x19mm",
+    "style": "handgun",
+    "fire mode": "semi-auto",
+    "decoder": "G19G5-*****"
+}

--- a/db/glock/G26/G26-Gen5-MOS.json
+++ b/db/glock/G26/G26-Gen5-MOS.json
@@ -1,0 +1,7 @@
+{
+    "barrel length": "3.43 inches",
+    "caliber": "9x19mm",
+    "style": "handgun",
+    "fire mode": "semi-auto",
+    "decoder": "G26G5MOS-*****"
+}

--- a/db/glock/G26/G26-Gen5.json
+++ b/db/glock/G26/G26-Gen5.json
@@ -1,0 +1,7 @@
+{
+    "barrel length": "3.43 inches",
+    "caliber": "9x19mm",
+    "style": "handgun",
+    "fire mode": "semi-auto",
+    "decoder": "G26G5-*****"
+}

--- a/db/glock/G34/G34-Gen5-MOS.json
+++ b/db/glock/G34/G34-Gen5-MOS.json
@@ -1,0 +1,7 @@
+{
+    "barrel length": "5.31 inches",
+    "caliber": "9x19mm",
+    "style": "handgun",
+    "fire mode": "semi-auto",
+    "decoder": "G34G5MOS-*****"
+}

--- a/db/glock/G34/G34-Gen5.json
+++ b/db/glock/G34/G34-Gen5.json
@@ -1,0 +1,7 @@
+{
+    "barrel length": "5.31 inches",
+    "caliber": "9x19mm",
+    "style": "handgun",
+    "fire mode": "semi-auto",
+    "decoder": "G34G5-*****"
+}

--- a/db/glock/G40/G40-MOS.json
+++ b/db/glock/G40/G40-MOS.json
@@ -1,0 +1,7 @@
+{
+    "barrel length": "6.02 inches",
+    "caliber": "10mm Auto",
+    "style": "handgun",
+    "fire mode": "semi-auto",
+    "decoder": "G40MOS-*****"
+}

--- a/db/glock/G41/G41-MOS.json
+++ b/db/glock/G41/G41-MOS.json
@@ -1,0 +1,7 @@
+{
+    "barrel length": "5.31 inches",
+    "caliber": ".45 Auto",
+    "style": "handgun",
+    "fire mode": "semi-auto",
+    "decoder": "G41MOS-*****"
+}

--- a/db/glock/G43/G43.json
+++ b/db/glock/G43/G43.json
@@ -1,0 +1,7 @@
+{
+    "barrel length": "3.39 inches",
+    "caliber": "9x19mm",
+    "style": "handgun",
+    "fire mode": "semi-auto",
+    "decoder": "G43-*****"
+}

--- a/db/glock/G43X/G43X-MOS.json
+++ b/db/glock/G43X/G43X-MOS.json
@@ -1,0 +1,7 @@
+{
+    "barrel length": "3.41 inches",
+    "caliber": "9x19mm",
+    "style": "handgun",
+    "fire mode": "semi-auto",
+    "decoder": "G43XMOS-*****"
+}

--- a/db/glock/G43X/G43X.json
+++ b/db/glock/G43X/G43X.json
@@ -1,0 +1,7 @@
+{
+    "barrel length": "3.41 inches",
+    "caliber": "9x19mm",
+    "style": "handgun",
+    "fire mode": "semi-auto",
+    "decoder": "G43X-*****"
+}

--- a/db/glock/G44/G44-22LR.json
+++ b/db/glock/G44/G44-22LR.json
@@ -1,0 +1,7 @@
+{
+    "barrel length": "4.02 inches",
+    "caliber": ".22 LR",
+    "style": "handgun",
+    "fire mode": "semi-auto",
+    "decoder": "G44-*****"
+}

--- a/db/glock/G45/G45-Gen5-MOS.json
+++ b/db/glock/G45/G45-Gen5-MOS.json
@@ -1,0 +1,7 @@
+{
+    "barrel length": "4.02 inches",
+    "caliber": "9x19mm",
+    "style": "handgun",
+    "fire mode": "semi-auto",
+    "decoder": "G45G5MOS-*****"
+}

--- a/db/glock/G45/G45-Gen5.json
+++ b/db/glock/G45/G45-Gen5.json
@@ -1,0 +1,7 @@
+{
+    "barrel length": "4.02 inches",
+    "caliber": "9x19mm",
+    "style": "handgun",
+    "fire mode": "semi-auto",
+    "decoder": "G45G5-*****"
+}

--- a/db/glock/G47/G47-Gen5-MOS.json
+++ b/db/glock/G47/G47-Gen5-MOS.json
@@ -1,0 +1,7 @@
+{
+    "barrel length": "4.49 inches",
+    "caliber": "9x19mm",
+    "style": "handgun",
+    "fire mode": "semi-auto",
+    "decoder": "G47G5MOS-*****"
+}

--- a/db/glock/G47/G47-Gen5.json
+++ b/db/glock/G47/G47-Gen5.json
@@ -1,0 +1,7 @@
+{
+    "barrel length": "4.49 inches",
+    "caliber": "9x19mm",
+    "style": "handgun",
+    "fire mode": "semi-auto",
+    "decoder": "G47G5-*****"
+}

--- a/db/glock/G48/G48-MOS.json
+++ b/db/glock/G48/G48-MOS.json
@@ -1,0 +1,7 @@
+{
+    "barrel length": "4.17 inches",
+    "caliber": "9x19mm",
+    "style": "handgun",
+    "fire mode": "semi-auto",
+    "decoder": "G48MOS-*****"
+}

--- a/db/glock/G48/G48.json
+++ b/db/glock/G48/G48.json
@@ -1,0 +1,7 @@
+{
+    "barrel length": "4.17 inches",
+    "caliber": "9x19mm",
+    "style": "handgun",
+    "fire mode": "semi-auto",
+    "decoder": "G48-*****"
+}


### PR DESCRIPTION
### Motivation
- Close coverage gaps in the Glock dataset by adding widely used Gen 5, MOS, long-slide, slimline/subcompact, and the G44 (.22 LR) variants. 
- Improve lookup and collector workflows by ensuring common Glock SKUs exist as separate variant files following the repo structure. 
- Provide consistent metadata (barrel length, caliber, style, fire mode, decoder) to support serial-decoding and CLI queries.

### Description
- Added 21 new JSON variant files under `db/glock/` representing Gen5 and MOS variants for G17, G19, G26, G34, G45, and G47. 
- Added G44 (.22 LR) as a distinct variant and long-slide entries such as `G17L` plus MOS entries for `G40` and `G41`. 
- Added slimline/subcompact entries including `G43`, `G43X` (with MOS), and `G48` (with MOS). 
- Each file includes the keys `barrel length`, `caliber`, `style`, `fire mode`, and a `decoder` pattern.

### Testing
- Validated that all new JSON files parse successfully using a Python `json.loads(...)` check (all files parsed with no errors). 
- Ran the CLI command `python gun_db.py variants Glock G19` to confirm the new variants are discoverable and the output includes `G19-Gen5` and `G19-Gen5-MOS`. 
- Verified upstream references via HTTP using `curl -I` as a fallback after a `requests`-based check failed due to the `requests` module being unavailable; `curl` requests returned successful HTTP headers.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699cecea3e3083329433226366d7ea57)