### PR TITLE
[FOLLOW-UP] Add missing Ruger variants (handgun, rifle, shotgun)

### DIFF
--- a/db/ruger/American-Rifle-Gen-II/46901.json
+++ b/db/ruger/American-Rifle-Gen-II/46901.json
@@ -1,0 +1,7 @@
+{
+    "barrel length": "20 inches",
+    "caliber": "6.5 Creedmoor",
+    "style": "rifle",
+    "fire mode": "bolt action",
+    "decoder": "RUG-ARG2-46901-*****"
+}

--- a/db/ruger/LCP-MAX/13760.json
+++ b/db/ruger/LCP-MAX/13760.json
@@ -1,0 +1,7 @@
+{
+    "barrel length": "2.8 inches",
+    "caliber": "380 Auto",
+    "style": "handgun",
+    "fire mode": "semi-auto",
+    "decoder": "RUG-LCPMAX-13760-*****"
+}

--- a/db/ruger/MAX-9/3514.json
+++ b/db/ruger/MAX-9/3514.json
@@ -1,0 +1,7 @@
+{
+    "barrel length": "3.2 inches",
+    "caliber": "9mm Luger",
+    "style": "handgun",
+    "fire mode": "semi-auto",
+    "decoder": "RUG-MAX9-3514-*****"
+}

--- a/db/ruger/Mark-IV-22-45-Lite/43955.json
+++ b/db/ruger/Mark-IV-22-45-Lite/43955.json
@@ -1,0 +1,7 @@
+{
+    "barrel length": "4.4 inches",
+    "caliber": "22 LR",
+    "style": "handgun",
+    "fire mode": "semi-auto",
+    "decoder": "RUG-MK42245L-43955-*****"
+}

--- a/db/ruger/Mark-IV-Competition/40112.json
+++ b/db/ruger/Mark-IV-Competition/40112.json
@@ -1,0 +1,7 @@
+{
+    "barrel length": "6.88 inches",
+    "caliber": "22 LR",
+    "style": "handgun",
+    "fire mode": "semi-auto",
+    "decoder": "RUG-MK4COMP-40112-*****"
+}

--- a/db/ruger/PC-Carbine/19100.json
+++ b/db/ruger/PC-Carbine/19100.json
@@ -1,0 +1,7 @@
+{
+    "barrel length": "16.12 inches",
+    "caliber": "9mm Luger",
+    "style": "rifle",
+    "fire mode": "semi-auto",
+    "decoder": "RUG-PCC-19100-*****"
+}

--- a/db/ruger/RXM/19400.json
+++ b/db/ruger/RXM/19400.json
@@ -1,0 +1,7 @@
+{
+    "barrel length": "4 inches",
+    "caliber": "9mm Luger",
+    "style": "handgun",
+    "fire mode": "semi-auto",
+    "decoder": "RUG-RXM-19400-*****"
+}

--- a/db/ruger/Red-Label-III/4511.json
+++ b/db/ruger/Red-Label-III/4511.json
@@ -1,0 +1,7 @@
+{
+    "barrel length": "30 inches",
+    "caliber": "20 Gauge",
+    "style": "shotgun",
+    "fire mode": "break action",
+    "decoder": "RUG-RL3-4511-*****"
+}

--- a/db/ruger/Security-380/3839.json
+++ b/db/ruger/Security-380/3839.json
@@ -1,0 +1,7 @@
+{
+    "barrel length": "3.42 inches",
+    "caliber": "380 Auto",
+    "style": "handgun",
+    "fire mode": "semi-auto",
+    "decoder": "RUG-SEC380-3839-*****"
+}


### PR DESCRIPTION
### Motivation
- Improve Ruger coverage in the dataset by adding known missing variants across handgun, rifle, and shotgun product lines to reduce lookup gaps.
- Source data points were confirmed from Ruger product pages to populate canonical variant fields.

### Description
- Added nine new variant JSON files under `db/ruger/` for MAX-9 (3514), LCP-MAX (13760), RXM (19400), Mark IV Competition (40112), Mark IV 22/45 Lite (43955), Security-380 (3839), American Rifle Gen II (46901), PC-Carbine (19100), and Red Label III (4511).
- Each new file follows the repository variant schema and includes the required fields `barrel length`, `caliber`, `style`, `fire mode`, and `decoder` and is placed in a model directory consistent with naming conventions.
- Created the necessary `db/ruger/{model}/` directories and committed the new files to the branch.

### Testing
- Ran `python -m py_compile gun_db.py` to verify CLI syntax and it succeeded.
- Ran a JSON parse validation over the new Ruger files (`python - <<'PY' ... json.loads(...)`) and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e54d9902dc833299a8e84afa9a6b8f)