### PR TITLE
[FOLLOW-UP] Add Mossberg MC2, 940 Pro Tactical OR, 590 Shockwave, and Patriot LR Tactical variants

### DIFF
--- a/db/mossberg/590-Shockwave/590-Shockwave-12ga.json
+++ b/db/mossberg/590-Shockwave/590-Shockwave-12ga.json
@@ -1,0 +1,7 @@
+{
+    "barrel length": "14 inches",
+    "caliber": "12 gauge",
+    "style": "shotgun",
+    "fire mode": "pump action",
+    "decoder": "590SW12-*****"
+}

--- a/db/mossberg/940-Pro-Tactical/940-Pro-Tactical-OR.json
+++ b/db/mossberg/940-Pro-Tactical/940-Pro-Tactical-OR.json
@@ -1,0 +1,7 @@
+{
+    "barrel length": "18.5 inches",
+    "caliber": "12 gauge",
+    "style": "shotgun",
+    "fire mode": "semi-auto",
+    "decoder": "940PTOR-*****"
+}

--- a/db/mossberg/MC2c/89030.json
+++ b/db/mossberg/MC2c/89030.json
@@ -1,0 +1,7 @@
+{
+    "barrel length": "3.9 inches",
+    "caliber": "9mm",
+    "style": "handgun",
+    "fire mode": "semi-auto",
+    "decoder": "89030-*****"
+}

--- a/db/mossberg/MC2c/89031.json
+++ b/db/mossberg/MC2c/89031.json
@@ -1,0 +1,7 @@
+{
+    "barrel length": "3.9 inches",
+    "caliber": "9mm",
+    "style": "handgun",
+    "fire mode": "semi-auto",
+    "decoder": "89031-*****"
+}

--- a/db/mossberg/MC2c/89032.json
+++ b/db/mossberg/MC2c/89032.json
@@ -1,0 +1,7 @@
+{
+    "barrel length": "3.9 inches",
+    "caliber": "9mm",
+    "style": "handgun",
+    "fire mode": "semi-auto",
+    "decoder": "89032-*****"
+}

--- a/db/mossberg/MC2c/89033.json
+++ b/db/mossberg/MC2c/89033.json
@@ -1,0 +1,7 @@
+{
+    "barrel length": "3.9 inches",
+    "caliber": "9mm",
+    "style": "handgun",
+    "fire mode": "semi-auto",
+    "decoder": "89033-*****"
+}

--- a/db/mossberg/MC2sc/89025.json
+++ b/db/mossberg/MC2sc/89025.json
@@ -1,0 +1,7 @@
+{
+    "barrel length": "3.4 inches",
+    "caliber": "9mm",
+    "style": "handgun",
+    "fire mode": "semi-auto",
+    "decoder": "89025-*****"
+}

--- a/db/mossberg/MC2sc/89027.json
+++ b/db/mossberg/MC2sc/89027.json
@@ -1,0 +1,7 @@
+{
+    "barrel length": "3.4 inches",
+    "caliber": "9mm",
+    "style": "handgun",
+    "fire mode": "semi-auto",
+    "decoder": "89027-*****"
+}

--- a/db/mossberg/MC2sc/89044.json
+++ b/db/mossberg/MC2sc/89044.json
@@ -1,0 +1,7 @@
+{
+    "barrel length": "3.4 inches",
+    "caliber": "9mm",
+    "style": "handgun",
+    "fire mode": "semi-auto",
+    "decoder": "89044-*****"
+}

--- a/db/mossberg/Patriot-LR-Tactical/28147.json
+++ b/db/mossberg/Patriot-LR-Tactical/28147.json
@@ -1,0 +1,7 @@
+{
+    "barrel length": "22 inches",
+    "caliber": "6.5mm Creedmoor",
+    "style": "long gun",
+    "fire mode": "bolt action",
+    "decoder": "28147-*****"
+}

--- a/db/mossberg/Patriot-LR-Tactical/28148.json
+++ b/db/mossberg/Patriot-LR-Tactical/28148.json
@@ -1,0 +1,7 @@
+{
+    "barrel length": "24 inches",
+    "caliber": "6.5 PRC",
+    "style": "long gun",
+    "fire mode": "bolt action",
+    "decoder": "28148-*****"
+}

--- a/db/mossberg/Patriot-LR-Tactical/28149.json
+++ b/db/mossberg/Patriot-LR-Tactical/28149.json
@@ -1,0 +1,7 @@
+{
+    "barrel length": "22 inches",
+    "caliber": "308 Win",
+    "style": "long gun",
+    "fire mode": "bolt action",
+    "decoder": "28149-*****"
+}


### PR DESCRIPTION
### Motivation
- Fill gaps in the Mossberg dataset by adding commonly encountered handgun, shotgun, and rifle variants (compact/subcompact MC2 family, 940 Pro Tactical OR, 590 Shockwave, and Patriot LR Tactical) to improve lookup coverage.

### Description
- Added 12 new JSON variant files under `db/mossberg/` across new model directories `MC2c`, `MC2sc`, `940-Pro-Tactical`, `590-Shockwave`, and `Patriot-LR-Tactical`.
- Handgun files include MC2c variants (`89030`, `89031`, `89032`, `89033`) and MC2sc variants (`89025`, `89027`, `89044`).
- Shotgun and rifle files include `940-Pro-Tactical-OR.json`, `590-Shockwave-12ga.json`, and Patriot LR Tactical variants (`28147`, `28148`, `28149`).
- Each file follows the repo schema with `barrel length`, `caliber`, `style`, `fire mode`, and `decoder` fields, and the changes were committed and a follow-up PR was opened.

### Testing
- Parsed all `db/mossberg/**/*.json` files with Python `json.load`, which succeeded and validated 13 JSON files.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e54daf4ea083328f8000541afe8797)