### PR TITLE
Add Shadow Systems manufacturer and base model variants

### DIFF
--- a/db/shadow-systems/AXIO/AXIO.json
+++ b/db/shadow-systems/AXIO/AXIO.json
@@ -1,0 +1,7 @@
+{
+    "barrel length": "4.4 inches",
+    "caliber": "9x19mm",
+    "style": "handgun",
+    "fire mode": "semi-auto",
+    "decoder": "AXIO-*****"
+}

--- a/db/shadow-systems/CR920/CR920.json
+++ b/db/shadow-systems/CR920/CR920.json
@@ -1,0 +1,7 @@
+{
+    "barrel length": "3.41 inches",
+    "caliber": "9x19mm",
+    "style": "handgun",
+    "fire mode": "semi-auto",
+    "decoder": "CR920-*****"
+}

--- a/db/shadow-systems/DR920/DR920.json
+++ b/db/shadow-systems/DR920/DR920.json
@@ -1,0 +1,7 @@
+{
+    "barrel length": "4.5 inches",
+    "caliber": "9x19mm",
+    "style": "handgun",
+    "fire mode": "semi-auto",
+    "decoder": "DR920-*****"
+}

--- a/db/shadow-systems/E526/E526.json
+++ b/db/shadow-systems/E526/E526.json
@@ -1,0 +1,7 @@
+{
+    "barrel length": "11.5 inches",
+    "caliber": "5.56x45mm",
+    "style": "pistol",
+    "fire mode": "semi-auto",
+    "decoder": "E526-*****"
+}

--- a/db/shadow-systems/MR920/MR920.json
+++ b/db/shadow-systems/MR920/MR920.json
@@ -1,0 +1,7 @@
+{
+    "barrel length": "4.01 inches",
+    "caliber": "9x19mm",
+    "style": "handgun",
+    "fire mode": "semi-auto",
+    "decoder": "MR920-*****"
+}

--- a/db/shadow-systems/U526/U526.json
+++ b/db/shadow-systems/U526/U526.json
@@ -1,0 +1,7 @@
+{
+    "barrel length": "16 inches",
+    "caliber": "5.56x45mm",
+    "style": "rifle",
+    "fire mode": "semi-auto",
+    "decoder": "U526-*****"
+}

--- a/db/shadow-systems/XR920/XR920.json
+++ b/db/shadow-systems/XR920/XR920.json
@@ -1,0 +1,7 @@
+{
+    "barrel length": "4.01 inches",
+    "caliber": "9x19mm",
+    "style": "handgun",
+    "fire mode": "semi-auto",
+    "decoder": "XR920-*****"
+}

--- a/db/shadow-systems/logo.json
+++ b/db/shadow-systems/logo.json
@@ -1,0 +1,3 @@
+{
+    "logo":"https://shadowsystemscorp.com/wp-content/uploads/2022/01/shadow-systems-logo.svg"
+}


### PR DESCRIPTION
## Summary
- Adds `db/shadow-systems/` with `logo.json` and base-model variant files for the full current lineup:
  - Pistols: **CR920** (subcompact 9mm), **MR920** (compact 9mm), **XR920** (crossover 9mm), **DR920** (full-size 9mm), **AXIO** (new-for-2026 9mm)
  - Rifles: **U526** (16" 5.56 rifle), **E526** (11.5" 5.56 pistol)
- Per-user scope: one variant per base model (7 files total); trim-level variants (Foundation/Combat/Elite/L/P/X/XP/XL) deferred to a follow-up.
- No changes to `gun_db.py` — pure data addition.

## Conventions followed
- Manufacturer dir `shadow-systems` (lowercase, hyphens — matches `smith-and-wesson`, `sig-sauer`).
- Model dirs preserve case (`CR920`, `AXIO`, `U526`) — matches `G17`, `P320`.
- Variant JSON uses the 5-field schema from `db/glock/G17/G17-Gen5.json`.
- `style: handgun` for striker-fired 920-family pistols, `style: rifle` for the U526 16", `style: pistol` for the E526 11.5" AR-platform pistol.

## Test plan
- [x] `python -m py_compile gun_db.py` — passes
- [x] `python gun_db.py --help` — passes
- [x] All 8 new JSON files parse via `json.loads`
- [x] Interactive shell: `makes` lists **Shadow Systems**; `models "Shadow Systems"` returns all 7 models; `get-info "Shadow Systems" CR920 CR920` returns the expected fields

https://claude.ai/code/session_01T2y6JJV5QwPNSH8ttHSDCr